### PR TITLE
Removed debub print

### DIFF
--- a/src/infer.rs
+++ b/src/infer.rs
@@ -340,7 +340,7 @@ impl Program {
         // let facts = self.extract_facts(config);
         let program = &self;
         // println!("FAX {:#?}", facts);
-        println!("RLZ {:#?}", program.rules);
+        // println!("RLZ {:#?}", program.rules);
         // let mode = InferenceMode::AlternatingFixpoint;
         let mut write_buf = Default::default();
         let mut assignments = Default::default();


### PR DESCRIPTION
There's some debug prints at the start of the `alternating_fixpoint`-function. It messses with my beautiful interface, so could you maybe remove it? :)

I've even done the work for you! Just hit "accept". I swear it won't do anything else than just this change!